### PR TITLE
RDKB-59721 : Reduce memory usage of xNetDP process

### DIFF
--- a/source/LatencyMeasurement/xNetDP/xNetDP.c
+++ b/source/LatencyMeasurement/xNetDP/xNetDP.c
@@ -118,8 +118,8 @@ typedef struct TCP_SNIFFER_ {
     u_short th_dport;
 }TcpSniffer;
 typedef struct {
-	long long Samples[SIZE];
-	long long Samples_age[SIZE];
+	long long Samples[MAX_SAMPLE];
+	long long Samples_age[MAX_SAMPLE];
 	long long Number_of_Samples;
 	double Percentile;
 }Calt_Percentile_info;
@@ -236,9 +236,9 @@ typedef struct LatencyTable
     bool   bHasLatencyEntry;
     int port[MAX_PORTS];
     int num_of_ports;
-    long long wanSamples[BUF_SIZE];
-    long long lanSamples[BUF_SIZE];
-    long long SamplesAges[BUF_SIZE];
+    long long wanSamples[MAX_SAMPLE];
+    long long lanSamples[MAX_SAMPLE];
+    long long SamplesAges[MAX_SAMPLE];
     long long Num_of_Sample;
     long long SampleAge;
     long long NthMaxValue;
@@ -246,7 +246,7 @@ typedef struct LatencyTable
     Calt_Percentile_info Percentile_info[2];
 }LatencyTable;
 
-#define MAX_NUM_OF_CLIENTS 100
+#define MAX_NUM_OF_CLIENTS 50
 
 LatencyTable Ipv4HashLatencyTable[MAX_NUM_OF_CLIENTS];
 LatencyTable Ipv6HashLatencyTable[MAX_NUM_OF_CLIENTS];


### PR DESCRIPTION
Reason for change: Reduce memory usage of xNetDP process

Test Procedure:
Validate 99th percentile.
Validate with more than 50 clients. 
Validate latency measurement 

Change-Id: I6ec883b7917ecf12e652a12efc7e9d5e5960d99a
Risks: low
Signed-off-by: Santosh Nayak SantoshRamesh_Nayak@cable.comcast.com
(cherry picked from commit 6835555424b265174616c4cd444306dfc3be296c)
(cherry picked from commit 3e8cbb6ed9f2e753d9aa536abfe24dcf2a3ccaa8)