### PR TITLE
 RDKB-60960 : Activate target when system time set to LKG

### DIFF
--- a/source/TandDSsp/current_time.c
+++ b/source/TandDSsp/current_time.c
@@ -194,13 +194,12 @@ void setClockEventFile()
     }
 }
 //create /tmp/systimeset when system time is set
-void setSystimeSetFile() 
+void activateSystimeTarget() 
 {
-    CcspTraceInfo(("File /tmp/systimeset going to set\n"))
     // Check if file already exists
     if (access(SYSTIME_SET_PATH, F_OK) != -1) 
     {
-    	CcspTraceInfo(("File /tmp/systimeset already exists\n"));
+    	CcspTraceInfo(("File system time set file already exists\n"));
     }
     else
     {
@@ -209,11 +208,11 @@ void setSystimeSetFile()
     	if (fileDescriptor != -1) 
     	{
        		close(fileDescriptor);
-        	CcspTraceInfo(("File /tmp/systimeset created successfully\n"));
+        	CcspTraceInfo(("File system  time set file created successfully\n"));
     	} 
     	else 
     	{
-        	CcspTraceError(("Failed to create /tmp/systimeset file\n"));
+        	CcspTraceError(("Failed to create system time set file\n"));
     	}
     }
 }
@@ -326,8 +325,8 @@ void* updateTimeThread(void* arg)
         }
     }
 
-    CcspTraceInfo(("Setting system-time-set target activation\n"));
-    setSystimeSetFile();
+    CcspTraceInfo(("Activating system-time-set.target\n"));
+    activateSystimeTarget();
     while (1) 
     {	
     	get_sleep_time(&sleep_time);

--- a/source/TandDSsp/current_time.c
+++ b/source/TandDSsp/current_time.c
@@ -193,7 +193,30 @@ void setClockEventFile()
     	}
     }
 }
-
+//create /tmp/systimeset when system time is set
+void setSystimeSetFile() 
+{
+    CcspTraceInfo(("File /tmp/systimeset going to set\n"))
+    // Check if file already exists
+    if (access(SYSTIME_SET_PATH, F_OK) != -1) 
+    {
+    	CcspTraceInfo(("File /tmp/systimeset already exists\n"));
+    }
+    else
+    {
+    	// Create the file
+    	int fileDescriptor = creat(SYSTIME_SET_PATH, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+    	if (fileDescriptor != -1) 
+    	{
+       		close(fileDescriptor);
+        	CcspTraceInfo(("File /tmp/systimeset created successfully\n"));
+    	} 
+    	else 
+    	{
+        	CcspTraceError(("Failed to create /tmp/systimeset file\n"));
+    	}
+    }
+}
 bool updateStoredTime(long long new_time) {
     //update stored time
     snprintf(buf, sizeof(buf), "%lld", (long long)new_time);
@@ -303,7 +326,8 @@ void* updateTimeThread(void* arg)
         }
     }
 
-
+    CcspTraceInfo(("Setting system-time-set target activation\n"));
+    setSystimeSetFile();
     while (1) 
     {	
     	get_sleep_time(&sleep_time);

--- a/source/TandDSsp/current_time.h
+++ b/source/TandDSsp/current_time.h
@@ -44,6 +44,7 @@
 #define BUILD_TIME_PATH 	"/version.txt"
 #define TIMEOFFSET_VALUE 	"timeoffset_ethwan_enable"
 #define CLOCK_EVENT_PATH 	"/tmp/clock-event"
+define SYSTIME_SET_PATH 	"/tmp/systimeset"
 #define SLEEP_TIME 		3600
 #define MAX_BUF_SIZE		128
 

--- a/source/TandDSsp/current_time.h
+++ b/source/TandDSsp/current_time.h
@@ -44,7 +44,7 @@
 #define BUILD_TIME_PATH 	"/version.txt"
 #define TIMEOFFSET_VALUE 	"timeoffset_ethwan_enable"
 #define CLOCK_EVENT_PATH 	"/tmp/clock-event"
-define SYSTIME_SET_PATH 	"/tmp/systimeset"
+#define SYSTIME_SET_PATH 	"/tmp/systimeset"
 #define SLEEP_TIME 		3600
 #define MAX_BUF_SIZE		128
 


### PR DESCRIPTION
Reason for change: Once TandDSsp  Set the system time activate
		   path based target

Test Procedure: Make sure system-set.target is active
Risks: Mid
Priority: P1