### PR TITLE
XER10-1954 : Self heal for speed test/ wan connectivity failures

### DIFF
--- a/scripts/selfheal_aggressive.sh
+++ b/scripts/selfheal_aggressive.sh
@@ -1685,7 +1685,6 @@ do
     fi
 
     if [ -f /etc/SelfHeal_Driver_Sanity_Check.sh ]; then
-    then
          /etc/SelfHeal_Driver_Sanity_Check.sh &
     fi
 


### PR DESCRIPTION
Reason for change: Self heal for speed test/ wan connectivity failures Test Procedure: build procedure
any password.
Risks:NA
Priority:P1

Signed-off-by: Michael_AmalAnand@comcast.com