### PR TITLE
RDKB-60124 :   Add T2 Markers for system time set

### DIFF
--- a/source/TandDSsp/Makefile.am
+++ b/source/TandDSsp/Makefile.am
@@ -34,7 +34,7 @@ CcspTandDSsp_CFLAGS = $(DEVICE_PRIORITIZATION_CFLAGS)
 endif
 
 CcspTandDSsp_SOURCES = tad_rbus_apis.c ssp_messagebus_interface.c ssp_action_priv.c ssp_main.c ssp_action.c ssp_messagebus_interface_priv.c dm_pack_datamodel.c current_time.c
-CcspTandDSsp_LDFLAGS = -lccsp_common -ldl -rdynamic -lrbus -lsyscfg
+CcspTandDSsp_LDFLAGS = -lccsp_common -ldl -rdynamic -lrbus -lsyscfg -lsecure_wrapper -ltelemetry_msgsender
 
 CcspTandDSsp_DEPENDENCIES = ${top_builddir}/source/LatencyMeasurement/TR-181/libLowLatency.la \
                             ${top_builddir}/source/LatencyMeasurement/ServiceMonitor/libCcspTandDSsp_ServiceMonitor.la 

--- a/source/TandDSsp/current_time.c
+++ b/source/TandDSsp/current_time.c
@@ -161,6 +161,7 @@ bool setSystemTime(time_t desired_epoch_time)
     new_timeval.tv_usec = 0;
     struct timespec uptime;
 	long long uptime_ms = 0;
+	char str[32];
 	
     if (settimeofday(&new_timeval, NULL) != 0) 
     {
@@ -171,10 +172,11 @@ bool setSystemTime(time_t desired_epoch_time)
 
      if (clock_gettime(CLOCK_MONOTONIC, &uptime) == 0)
     {
-        long long uptime_ms = (long long)uptime.tv_sec * 1000LL + (uptime.tv_nsec / 1000000LL);
+        uptime_ms = (long long)uptime.tv_sec * 1000LL + (uptime.tv_nsec / 1000000LL);
     }
     CcspTraceInfo(("System time set successfully.Uptime: %lld ms\n", uptime_ms));
-    t2_event_s("SYST_INFO_SETSYSTIME", uptime_ms); 
+	snprintf(str, sizeof(str), "%lld", uptime_ms);
+    t2_event_s("SYST_INFO_SETSYSTIME", str); 
 
     return true;
 }

--- a/source/TandDSsp/current_time.c
+++ b/source/TandDSsp/current_time.c
@@ -233,6 +233,7 @@ long long str_to_int_conv(char *str_value)
 //Function to check if device time is greater or build time
 void UpdatedeviceTimeorbuildTime(long long currentEpochTime, long long build_epoch)
 {
+	char time_str[32];
     CcspTraceInfo(("Current Epoch Time: %lld, Build Epoch Time: %lld\n", (long long)currentEpochTime, (long long)build_epoch));
     timeoffset_ethwan_enable = (build_epoch > currentEpochTime) ? build_epoch : currentEpochTime;
     // Store initial timeoffset_ethwan_enable value
@@ -245,7 +246,8 @@ void UpdatedeviceTimeorbuildTime(long long currentEpochTime, long long build_epo
             //set system time as build time
             setSystemTime(stored_time);
             CcspTraceInfo(("System time set to build time: %lld\n", stored_time));
-			t2_event_s("SYST_INFO_SYSBUILD",stored_time);
+			snprintf(time_str, sizeof(time_str), "%lld", stored_time);
+			t2_event_s("SYST_INFO_SYSBUILD",time_str);
         }
     } 
 }
@@ -271,6 +273,7 @@ void get_sleep_time(unsigned int *sleep_time)
 void* updateTimeThread(void* arg) 
 {
     unsigned int sleep_time;
+	char time_str[32];
     pthread_detach(pthread_self());
     CcspTraceInfo(("updateTimeThread_create thread created successfully\n"));
     
@@ -303,7 +306,8 @@ void* updateTimeThread(void* arg)
           			if(setSystemTime(stored_time))
                                 {
           				CcspTraceInfo(("System time set as stored time: %lld after reboot as it is greater\n",stored_time));
-									t2_event_s("SYST_INFO_SYSLKG",stored_time);
+									snprintf(time_str, sizeof(time_str), "%lld", stored_time);
+									t2_event_s("SYST_INFO_SYSLKG",time_str);
                                 }
           		}
           		else

--- a/source/TandDSsp/current_time.c
+++ b/source/TandDSsp/current_time.c
@@ -160,6 +160,7 @@ bool setSystemTime(time_t desired_epoch_time)
     new_timeval.tv_sec = desired_epoch_time;
     new_timeval.tv_usec = 0;
     struct timespec uptime;
+	long long uptime_ms = 0;
 	
     if (settimeofday(&new_timeval, NULL) != 0) 
     {

--- a/source/TandDSsp/ssp_main.c
+++ b/source/TandDSsp/ssp_main.c
@@ -306,6 +306,7 @@ int main(int argc, char* argv[])
     AnscSetTraceLevel(CCSP_TRACE_LEVEL_INFO);
 #endif
 
+	t2_init("CcspTandDSsp");
     for (idx = 1; idx < argc; idx++)
     {
         if ( (strcmp(argv[idx], "-subsys") == 0) )

--- a/source/TandDSsp/ssp_main.c
+++ b/source/TandDSsp/ssp_main.c
@@ -49,6 +49,7 @@
 #include "tad_rbus_apis.h"
 #include "lowlatency_apis.h"
 #include "current_time.h"
+#include <telemetry_busmessage_sender.h>
 
 #ifdef DEVICE_PRIORITIZATION_ENABLED
 #include "device_prio_apis.h"


### PR DESCRIPTION
Code changes to integrate T2 to indicate 
1) The time when system time is set
2) Source of the system time
