### PR TITLE
LTE-2742 : Slef heal for RFC sync

### DIFF
--- a/scripts/selfheal_rfc.sh
+++ b/scripts/selfheal_rfc.sh
@@ -25,8 +25,7 @@ RETRY_COUNT=0
 # Define 'echo_t'
 if [ -f /etc/log_timestamp.sh ]; then
     source /etc/log_timestamp.sh
-fi
-if ! type echo_t >/dev/null 2>&1; then
+else
     echo_t() { echo "$@"; }
 fi
 

--- a/scripts/selfheal_rfc.sh
+++ b/scripts/selfheal_rfc.sh
@@ -34,7 +34,7 @@ fi
 cleanup() {
     rm -f "$LOCKFILE"
 }
-trap cleanup EXIT
+trap cleanup INT TERM EXIT
 
 # Create lock file to prevent multiple instances of this script
 touch "$LOCKFILE"
@@ -47,8 +47,8 @@ while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
         if [ -f /lib/rdk/rfc.service ]; then
             echo_t "[RFC_SELFHEAL] : File $RFC_SYNC_DONE not found. Restarting RFC service"
             systemctl restart rfc.service
-            # sleep for 3 minutes
-            sleep 180
+            # 300 seconds in pre + 3 minutes for the sync to take place.
+            sleep 480
         else
             echo_t "[RFC_SELFHEAL] : rfc.service not found. Unable to Restart it."
             exit 0

--- a/scripts/selfheal_rfc.sh
+++ b/scripts/selfheal_rfc.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+#######################################################################################
+# If not stated otherwise in this file or this component's LICENSE file the
+# following copyright and licenses apply:
+#
+#  Copyright 2025 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#######################################################################################
+RFC_SYNC_DONE="/tmp/.rfcSyncDone"
+LOCKFILE="/tmp/rfcSelfhealLock"
+MAX_RETRIES=3
+RETRY_COUNT=0
+
+# Define 'echo_t'
+if [ -f /etc/log_timestamp.sh ]; then
+    source /etc/log_timestamp.sh
+fi
+if ! type echo_t >/dev/null 2>&1; then
+    echo_t() { echo "$@"; }
+fi
+
+# Always remove lockfile on exit
+cleanup() {
+    rm -f "$LOCKFILE"
+}
+trap cleanup EXIT
+
+# Create lock file to prevent multiple instances of this script
+touch "$LOCKFILE"
+
+while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+    if [ -f "$RFC_SYNC_DONE" ]; then
+        echo_t "[RFC_SELFHEAL] : File $RFC_SYNC_DONE exists. Exiting."
+        exit 0
+    else
+        if [ -f /lib/rdk/rfc.service ]; then
+            echo_t "[RFC_SELFHEAL] : File $RFC_SYNC_DONE not found. Restarting RFC service"
+            systemctl restart rfc.service
+            # sleep for 3 minutes
+            sleep 180
+        else
+            echo_t "[RFC_SELFHEAL] : rfc.service not found. Unable to Restart it."
+            exit 0
+        fi
+    fi
+    RETRY_COUNT=$((RETRY_COUNT + 1))
+done
+echo_t "[RFC_SELFHEAL] : Max retries ($MAX_RETRIES) reached. Exiting."

--- a/scripts/task_health_monitor.sh
+++ b/scripts/task_health_monitor.sh
@@ -4856,7 +4856,7 @@ hcm_handle_recovery() {
 self_heal_rfc()
 {
     if [ -f /tmp/.rfcSyncDone ]; then
-        echo_t "[RDKB_SELFHEAL] : RFC sync is completed"
+        echo_t "[RFC_SELFHEAL] : RFC sync is completed"
     else
         if [ ! -f /tmp/rfcSelfhealLock ]; then
             echo_t "[RFC_SELFHEAL] : RFC sync not done.Triggering RFC Self healing"

--- a/scripts/task_health_monitor.sh
+++ b/scripts/task_health_monitor.sh
@@ -4852,6 +4852,25 @@ hcm_handle_recovery() {
     fi
 }
 
+#Restart RFC service, if the RFC sync not happened
+self_heal_rfc()
+{
+    if [ -f /tmp/.rfcSyncDone ]; then
+        echo_t "[RDKB_SELFHEAL] : RFC sync is completed"
+    else
+        if [ ! -f /tmp/rfcSelfhealLock ]; then
+            echo_t "[RFC_SELFHEAL] : RFC sync not done.Triggering RFC Self healing"
+            if [ -f /usr/ccsp/tad/selfheal_rfc.sh ]; then
+                sh /usr/ccsp/tad/selfheal_rfc.sh &
+            else
+                echo_t "[RFC_SELFHEAL] : selfheal_rfc.sh script not present"
+            fi
+        else
+            echo_t "[RFC_SELFHEAL] : RFC Self healing is already in progress"
+        fi
+     fi
+}
+
 self_heal_ethwan_mode_recover()
 {
 
@@ -5042,6 +5061,7 @@ case $SELFHEAL_TYPE in
       ;;
 esac
 
+self_heal_rfc
 self_heal_dual_cron
 self_heal_meshAgent
 self_heal_meshAgent_hung


### PR DESCRIPTION
Reason for change: RFC service is unable to download RFCs from Xconf, so added self heal for RF sync.

Test Procedure: Make sure rfc.service should restart if "/tmp/.rfcSyncDone" not found.
Risks: NA
Priority: P1