### PR TITLE
RDKB-60124 : Add T2 Markers for system time set

### DIFF
--- a/source/TandDSsp/current_time.c
+++ b/source/TandDSsp/current_time.c
@@ -176,7 +176,7 @@ bool setSystemTime(time_t desired_epoch_time)
     }
     CcspTraceInfo(("System time set successfully.\n"));
 	snprintf(uptime_str, sizeof(uptime_str), "%lld", uptime_ms);
-    t2_event_s("SYST_INFO_SETSYSTIME", uptime_str); 
+    t2_event_s("SYST_INFO_SETSYSTIME_split", uptime_str); 
 
     return true;
 }
@@ -269,7 +269,7 @@ void UpdatedeviceTimeorbuildTime(long long currentEpochTime, long long build_epo
             setSystemTime(stored_time);
             CcspTraceInfo(("System time set to build time: %lld\n", stored_time));
 			snprintf(time_str, sizeof(time_str), "%lld", stored_time);
-			t2_event_s("SYST_INFO_SYSBUILD",time_str);
+			t2_event_s("SYST_INFO_SYSBUILD_split",time_str);
         }
     } 
 }
@@ -329,7 +329,7 @@ void* updateTimeThread(void* arg)
                                 {
           				CcspTraceInfo(("System time set as stored time: %lld after reboot as it is greater\n",stored_time));
 									snprintf(time_str, sizeof(time_str), "%lld", stored_time);
-									t2_event_s("SYST_INFO_SYSLKG",time_str);
+									t2_event_s("SYST_INFO_SYSLKG_split",time_str);
                                 }
           		}
           		else


### PR DESCRIPTION
Code change to change the event marker as split

The time when system time is set
Source of the system time