### PR TITLE
RDKDEV-1135, RDKBACCL-846: Migrate scripts from RPI to BPI

### DIFF
--- a/scripts/selfheal_aggressive.sh
+++ b/scripts/selfheal_aggressive.sh
@@ -261,7 +261,7 @@ self_heal_interfaces()
     case $SELFHEAL_TYPE in
         "BASE")
             # Checking whether brlan0 and l2sd0.100 are created properly , if not recreate it
-	    if [ "$MODEL_NAME" = "RPI" ]; then
+	    if [ "$MODEL_NAME" = "RPI" ] || [ "$MODEL_NAME" = "BPI" ]; then
                  device_mode=$(dmcli eRT retv Device.X_CISCO_COM_DeviceControl.LanManagementEntry.1.LanMode)
                 if [ ! -f /tmp/.router_reboot ]; then
                     if [ "$device_mode" != "" ]; then
@@ -1615,7 +1615,8 @@ if [ "$MODEL_NUM" != "TG3482G" ] && [ "$MODEL_NUM" != "CGA4131COM" ] &&
    [ "$MODEL_NUM" != "CGA4332COM" ] && [ "$MODEL_NUM" != "CVA601ZCOM" ] &&
    [ "$MODEL_NUM" != "VTER11QEL" ] &&
    [ "$MODEL_NUM" != "CGM601TCOM" ] && [ "$MODEL_NUM" != "SG417DBCT" ] &&
-   [ "$MODEL_NUM" != "SCER11BEL" ] && [ "$MODEL_NAME" != "RPI" ]
+   [ "$MODEL_NUM" != "SCER11BEL" ] && [ "$MODEL_NAME" != "RPI" ] &&
+   [ "$MODEL_NAME" != "BPI" ]
 then
     exit
 fi


### PR DESCRIPTION
Reason for change: Migrate scripts from RPI to BPI
Test Procedure: Image should bootup and all functionality should work
Risks: Low