### PR TITLE
LTE-2645 : LTE SelfHeal Enhancement

### DIFF
--- a/source/xle_selfheal/xle_selfheal_util.c
+++ b/source/xle_selfheal/xle_selfheal_util.c
@@ -52,6 +52,7 @@ struct xle_attributes
   int is_default_route;
   int is_mesh_default_route;
   int cellular_restart_count;
+  int cellular_retry_count;
 }xle_attributes;
 
 #define BUFLEN_128  128
@@ -163,7 +164,7 @@ void check_cellular_interface(void)
         if(count >= 3)
         {
             xle_log("[xle_self_heal] Rebooting in next selfheal cycle because wwan0 not available\n");
-            sysevent_set(sysevent_fd, sysevent_token, "LTE_DOWN", "1", 0);
+            sysevent_set(sysevent_fd, sysevent_token, "LTE_DOWN", "WWAN0_DOWN", 0);
             break;
         }
         count++;
@@ -175,11 +176,13 @@ void PopulateParameters()
 {
     char mesh_status[128] = {0};
     char countBuffer[4] = {0};
+    char retryBuffer[4] = {0};
     sysevent_fd =  sysevent_open("127.0.0.1", SE_SERVER_WELL_KNOWN_PORT, SE_VERSION, "xle_selfheal", &sysevent_token);
     sysevent_get(sysevent_fd, sysevent_token, "wan_ifname", default_wan_ifname, sizeof(default_wan_ifname));
     sysevent_get(sysevent_fd, sysevent_token, "current_wan_ifname", current_wan_ifname, sizeof(current_wan_ifname));
     sysevent_get(sysevent_fd, sysevent_token, "mesh_wan_linkstatus", mesh_status, sizeof(mesh_status));
     sysevent_get(sysevent_fd, sysevent_token, "cellular_restart_count", countBuffer, sizeof(countBuffer));
+    sysevent_get(sysevent_fd, sysevent_token, "cellular_retry_count", retryBuffer, sizeof(retryBuffer));
     char *paramValue = NULL;
     char*  component_id = "ccsp.xle_self";
     CCSP_Message_Bus_Init(component_id,
@@ -192,7 +195,20 @@ void PopulateParameters()
     {        strncpy(mesh_interface_name,paramValue,sizeof(mesh_interface_name)-1);
         ((CCSP_MESSAGE_BUS_INFO *)bus_handle)->freefunc(paramValue);
     }
-    check_cellular_interface();
+
+    //check the last reboot reason is in LTE_DOWN or in WWAN0_DOWN
+    char buf[8] = {0};
+    if (0 == syscfg_get(NULL, "X_RDKCENTRAL-COM_LastRebootReason", buf, sizeof(buf)))
+    {
+        if (buf[0] != '\0')
+        {
+            if (strcmp(buf, "WWAN0_DOWN") != 0)
+            {
+                check_cellular_interface();
+            }
+        }
+    }
+
     check_lte_provisioned(lte_wan_status, lte_backup_enable, lte_interface_enable, ipaddr_family);
     if(( 0 == strncmp( lte_wan_status, "CONNECTED", 9 )) && ( 0 == strncmp( lte_backup_enable, "true", 4 )))
     {
@@ -426,6 +442,7 @@ void PopulateParameters()
         }
     }
     xle_params.cellular_restart_count = atoi(countBuffer);
+    xle_params.cellular_retry_count = atoi(retryBuffer);
 }
 
 void isWan_up()
@@ -644,26 +661,43 @@ int main(int argc,char *argv[])
     
     //LTE SelfHeal Enhancement
     xle_log("[xle_self_heal] ip address family: %s\n", ipaddr_family);
-    if((0 == strncmp( lte_interface_enable, "true", 4)) && ( 0 == strncmp( lte_backup_enable, "true", 4 )))
+    char count1[2];
+    char retry_buff[2];
+    if(((0 == strncmp( lte_interface_enable, "true", 4)) && ( 0 == strncmp( lte_backup_enable, "true", 4 ))) &&
+        ((0 != strncmp( lte_wan_status, "CONNECTED", 9 )) || ((strstr(ipaddr_family,"IPv4")) && (xle_params.is_ipv4present == 0)) || ((strstr(ipaddr_family,"IPv6")) && (xle_params.is_ipv6present == 0))))
     {
-        if((0 != strncmp( lte_wan_status, "CONNECTED", 9 )) || ((strstr(ipaddr_family,"IPv4")) && (xle_params.is_ipv4present == 0)) || ((strstr(ipaddr_family,"IPv6")) && (xle_params.is_ipv6present == 0)))
+        if(xle_params.cellular_retry_count < 3)
+        {
+            int retry_count = xle_params.cellular_retry_count;
+            retry_count+=1;
+            snprintf(retry_buff, sizeof(retry_buff), "%d", retry_count);
+            sysevent_set(sysevent_fd, sysevent_token, "cellular_retry_count", retry_buff, 0);
+            xle_log("[xle_self_heal] Cellular manager retry count:%d \n", retry_count);
+        }
+        else
         {
             if(xle_params.cellular_restart_count < 3)
             {
                 int count = xle_params.cellular_restart_count;
-                char count1[2];
                 count+=1;
                 snprintf(count1, sizeof(count1), "%d", count);
                 sysevent_set(sysevent_fd, sysevent_token, "cellular_restart_count", count1, 0);
                 system("systemctl restart RdkCellularManager.service &");
                 xle_log("[xle_self_heal] Cellular manager restarted. Number of times restarted=%d \n", count);
-            }
-            else
-            {
+             }
+             else
+             {
                 xle_log("[xle_self_heal] Today's limit for cellular manager restart has exceeded\n");
-                sysevent_set(sysevent_fd, sysevent_token, "LTE_DOWN", "1", 0);
-            }
+                sysevent_set(sysevent_fd, sysevent_token, "LTE_DOWN", "LTE_DOWN", 0);
+             }
         }
+    }
+    else{
+         xle_log("[xle_self_heal] Reset counters for cellular retries and restarts\n");
+         xle_params.cellular_retry_count = 0;
+         sysevent_set(sysevent_fd, sysevent_token, "cellular_retry_count", "0", 0);
+         xle_params.cellular_restart_count = 0;
+         sysevent_set(sysevent_fd, sysevent_token, "cellular_restart_count", "0", 0);
     }
     
     if ( logFp != NULL)


### PR DESCRIPTION
Reason for change:
Enhancing SelfHeal for LTE network

Test Procedure:
1. If X_RDK_Status is not 'Connected' or wwan0 has no IPv4/IPv6, Cellular Manager should retry 3 times, then restart.
2. If still no connectivity, it should set LTE_DOWN and in the next SelfHeal cycle, device should reboot with reason LTE_DOWN.
3. Cellular Manager should restart only 3 times per day.
4. If wwan0 comes up, retry and restart counters should reset to 0.
5. After every 24 hours, cellular_restart_count and cellular_retry_count should be reset to 0.
6. If wwan0 interface is missing, set reboot reason as WWAN0_DOWN.
7. In the next cycle, if reason is WWAN0_DOWN, renewal should stop.

Change-Id: I5703da070f6d242f601169e0ce01148df40c59d2 Risks: None
Signed-off-by: kavya_chowdahallisuresh@comcast.com (cherry picked from commit e4f305d033ed6ce6a6a252a279e152dac2cc5dae) (cherry picked from commit fdcad705b9b770ef13233f18786d9917f8026f08) (cherry picked from commit 8e2ebb3b8abad1178e648ea6cb655eeb2a34d944)