### PR TITLE
Feature/test wanfailover - adding WanFailover for RDK_AutomationTest

### DIFF
--- a/.github/workflows/fossid_integration_stateless_diffscan_target_repo.yml
+++ b/.github/workflows/fossid_integration_stateless_diffscan_target_repo.yml
@@ -1,11 +1,18 @@
 name: Fossid Stateless Diff Scan
 
-on: pull_request
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   call-fossid-workflow:
-    uses: rdkcentral/build_tools_workflows/.github/workflows/fossid_integration_stateless_diffscan.yml@develop
-    secrets: 
+    if: ${{ ! github.event.pull_request.head.repo.fork }}
+    uses: rdkcentral/build_tools_workflows/.github/workflows/fossid_integration_stateless_diffscan.yml@1.0.0
+    secrets:
         FOSSID_CONTAINER_USERNAME: ${{ secrets.FOSSID_CONTAINER_USERNAME }}
         FOSSID_CONTAINER_PASSWORD: ${{ secrets.FOSSID_CONTAINER_PASSWORD }}
         FOSSID_HOST_USERNAME: ${{ secrets.FOSSID_HOST_USERNAME }}

--- a/source/dmltad/cosa_rdktest_dml.c
+++ b/source/dmltad/cosa_rdktest_dml.c
@@ -343,7 +343,34 @@ X_RDK_AutomationTest_SetParamStringValue
                     dlclose(handle);
                     return FALSE;
                 }
-            } else {
+            }
+            else if (strncasecmp(pString, "WANFailover\n", 13) == 0){
+                int (*TriggerWFOTest)(char*);
+                *(void **)&TriggerWFOTest = dlsym(handle, "TriggerWFOTest");
+                if ((error == dlerror()) != NULL){
+                    fprintf(stderr, "%s\n", error);
+                    dlclose(handle);
+                    return FALSE;
+                }
+
+                AnscTraceFlow(("Input string %s\n", pString));
+
+                if (FALSE == is_test_running()) {
+                    char *input = pString + 13; //"WANFailover\nphase=BeforeWFO"
+                    int status = TriggerWFOTest(input);
+                    if (status != 0) {
+                        AnscTraceWarning(("%s : Failed to start WFO test\n", __FUNCTION__));
+                        dlclose(handle);
+                        return FALSE;
+                    }
+                }
+                else {
+                    AnscTraceWarning(("%s : Automation test is already running\n", __FUNCTION__));
+                    dlclose(handle);
+                    return FALSE;
+                }
+            }
+             else {
                 AnscTraceWarning(("%s : Invalid test name '%s'\n", __FUNCTION__, pString));
                 dlclose(handle);
                 return FALSE;

--- a/source/dmltad/cosa_rdktest_dml.c
+++ b/source/dmltad/cosa_rdktest_dml.c
@@ -347,7 +347,7 @@ X_RDK_AutomationTest_SetParamStringValue
             else if (strncasecmp(pString, "WANFailover|", 12) == 0){
                 int (*TriggerWFOTest)(char*);
                 *(void **)&TriggerWFOTest = dlsym(handle, "TriggerWFOTest");
-                if ((error == dlerror()) != NULL){
+                if ((error = dlerror()) != NULL){
                     fprintf(stderr, "%s\n", error);
                     dlclose(handle);
                     return FALSE;

--- a/source/dmltad/cosa_rdktest_dml.c
+++ b/source/dmltad/cosa_rdktest_dml.c
@@ -344,7 +344,7 @@ X_RDK_AutomationTest_SetParamStringValue
                     return FALSE;
                 }
             }
-            else if (strncasecmp(pString, "WANFailover\n", 13) == 0){
+            else if (strncasecmp(pString, "WANFailover|", 12) == 0){
                 int (*TriggerWFOTest)(char*);
                 *(void **)&TriggerWFOTest = dlsym(handle, "TriggerWFOTest");
                 if ((error == dlerror()) != NULL){
@@ -356,7 +356,7 @@ X_RDK_AutomationTest_SetParamStringValue
                 AnscTraceFlow(("Input string %s\n", pString));
 
                 if (FALSE == is_test_running()) {
-                    char *input = pString + 13; //"WANFailover\nphase=BeforeWFO"
+                    char *input = pString + 12; //"WANFailover|phase=BeforeWFO"
                     int status = TriggerWFOTest(input);
                     if (status != 0) {
                         AnscTraceWarning(("%s : Failed to start WanFailover test\n", __FUNCTION__));

--- a/source/dmltad/cosa_rdktest_dml.c
+++ b/source/dmltad/cosa_rdktest_dml.c
@@ -359,7 +359,7 @@ X_RDK_AutomationTest_SetParamStringValue
                     char *input = pString + 13; //"WANFailover\nphase=BeforeWFO"
                     int status = TriggerWFOTest(input);
                     if (status != 0) {
-                        AnscTraceWarning(("%s : Failed to start Wanfailover test\n", __FUNCTION__));
+                        AnscTraceWarning(("%s : Failed to start WanFailover test\n", __FUNCTION__));
                         dlclose(handle);
                         return FALSE;
                     }

--- a/source/dmltad/cosa_rdktest_dml.c
+++ b/source/dmltad/cosa_rdktest_dml.c
@@ -359,7 +359,7 @@ X_RDK_AutomationTest_SetParamStringValue
                     char *input = pString + 13; //"WANFailover\nphase=BeforeWFO"
                     int status = TriggerWFOTest(input);
                     if (status != 0) {
-                        AnscTraceWarning(("%s : Failed to start WFO test\n", __FUNCTION__));
+                        AnscTraceWarning(("%s : Failed to start Wanfailover test\n", __FUNCTION__));
                         dlclose(handle);
                         return FALSE;
                     }


### PR DESCRIPTION
To implement WANFailover testing for TCXB in RATS, added support for "WANFailover" in X_RDK_AutomationTest_SetParamStringValue()