### PR TITLE
RDKB-61612 : WAN Failover Utility is required in Ethwan mode similar to DOCSIS

### DIFF
--- a/scripts/selfheal_aggressive.sh
+++ b/scripts/selfheal_aggressive.sh
@@ -622,7 +622,7 @@ self_heal_interfaces()
               if [ "$ethWan_if" != "" ]; then
                  # During Eth WAN failover simulation test, skip selfheal for bringing up Eth WAN port.
                  if [ -f /tmp/.EWanLinkDown_TestRunning.txt ]; then
-                    echo_t "[RDKB_AGG_SELFHEAL] : Eth WAN failover simulation test is going on. Hence, skipping selfheal this time."
+                    echo_t "[RDKB_AGG_SELFHEAL] : Eth WAN failover simulation test is going on. Hence, skipping selfheal this iteration."
                  else
                     echo_t "[RDKB_AGG_SELFHEAL] : $WAN_INTERFACE has no ip address, bring down and up Eth WAN port interface:$ethWan_if"
                     ip link set dev $ethWan_if down

--- a/scripts/selfheal_aggressive.sh
+++ b/scripts/selfheal_aggressive.sh
@@ -620,10 +620,15 @@ self_heal_interfaces()
               fi
 
               if [ "$ethWan_if" != "" ]; then
-                 echo_t "[RDKB_AGG_SELFHEAL] : $WAN_INTERFACE has no ip address, bring down and up Eth WAN port interface:$ethWan_if"
-                 ip link set dev $ethWan_if down
-                 sleep 5
-                 ip link set dev $ethWan_if up
+                 # During Eth WAN failover simulation test, skip selfheal for bringing up Eth WAN port.
+                 if [ -f /tmp/.EWanLinkDown_TestRunning.txt ]; then
+                    echo_t "[RDKB_AGG_SELFHEAL] : Eth WAN failover simulation test is going on. Hence, skipping selfheal this time."
+                 else
+                    echo_t "[RDKB_AGG_SELFHEAL] : $WAN_INTERFACE has no ip address, bring down and up Eth WAN port interface:$ethWan_if"
+                    ip link set dev $ethWan_if down
+                    sleep 5
+                    ip link set dev $ethWan_if up
+                 fi
               else
                  echo_t "[RDKB_AGG_SELFHEAL] : Eth Wan Interface returned empty skipping recovery."
               fi


### PR DESCRIPTION
RDKB-61612 : WAN Failover Utility is required in Ethwan mode similar to DOCSIS
Reason for change: Enable WAN Failover simulation in EthWAN mode
Test Procedure: Set this "Device.X_RDKCENTRAL-COM_EthernetWAN.LinkDown" TR181 param
to true for verifying the WAN failover simulation is happening or not when device is in EthWAN mode.
Risks: Low
Priority: P1
