### PR TITLE
RDKCOM-5557: RDKBDEV-3398: Adding one more way to get the ipV6 address along with the existing implementation

### DIFF
--- a/scripts/self_heal_connectivity_test.sh
+++ b/scripts/self_heal_connectivity_test.sh
@@ -304,7 +304,14 @@ runPingTest()
 	   then
 	      erouterIP6=`ifconfig $WAN_INTERFACE | grep inet6 | grep Link | head -n1 | awk '{print $(NF-1)}' | cut -f1 -d:`
 	      routeEntry=`ip -6 neigh show | grep $WAN_INTERFACE | grep $erouterIP6`
-              IPv6_Gateway_addr=`echo "$routeEntry" | grep lladdr |cut -f1 -d ' '` 	
+
+              if [ "$routeEntry" != "" ]
+              then
+                 IPv6_Gateway_addr=`echo "$routeEntry" | grep lladdr |cut -f1 -d ' '`
+              else
+                 routeEntry=`route -A inet6 | grep -w $WAN_INTERFACE | grep $erouterIP6 | cut -d'/' -f1 | tail -1`
+                 IPv6_Gateway_addr=`echo $routeEntry | sed 's/ *$//g'`
+              fi
     	   fi
 	fi	
 	fi #LTE-133 ping to ipv6 not needed for xle.


### PR DESCRIPTION

Reason for change: providing more stability for ping test
Risks: None