### PR TITLE
XB9-1022: Ethernet Clients not reporting post upgrade to 8.3p3s1 due to ethernet interface 1 is going down

### DIFF
--- a/scripts/selfheal_bootup.sh
+++ b/scripts/selfheal_bootup.sh
@@ -992,11 +992,12 @@ fi
 # Tech XB7  => MODEL_NUM=CGM4331COM
 # CMX  XB7  => MODEL_NUM=TG4482A - not included
 # Tech XB8  => MODEL_NUM=CGM4981COM
+# Tech XB9  => MODEL_NUM=CWA438TCOM
 # Tech XB10    => MODEL_NUM=CGM601TCOM
 # Sercomm XB10 => MODEL_NUM=SG417DBCT
 
-if [ "$MODEL_NUM" = "CGM4331COM" ] || [ "$MODEL_NUM" = "CGM4981COM" ] || [ "$MODEL_NUM" = "CGM601TCOM" ] || \
-   [ "$MODEL_NUM" = "SG417DBCT" ]; then
+if [ "$MODEL_NUM" = "CGM4331COM" ] || [ "$MODEL_NUM" = "CGM4981COM" ] || [ "$MODEL_NUM" = "CWA438TCOM" ] || \
+   [ "$MODEL_NUM" = "CGM601TCOM" ] || [ "$MODEL_NUM" = "SG417DBCT" ]; then
 
   echo_t "RDKB_SELFHEAL: Starting ethagent script..."
   ETHAGENT_SCRIPT="$TAD_PATH/ethagent_associated_dev.sh"


### PR DESCRIPTION
Reason for change: ported from RDKB-62729 and make model name update
Test Procedure: Build & Verify
Risks: NA
Priority: P1
Signed-off-by: Desu sravya <desu.sravya@vantiva.com>