### PR TITLE
LTE-2901 : LTE_DOWN reboot is seen in case or br-home not available

### DIFF
--- a/source/xle_selfheal/xle_selfheal_util.c
+++ b/source/xle_selfheal/xle_selfheal_util.c
@@ -196,8 +196,8 @@ void PopulateParameters()
     if (ret != CCSP_SUCCESS)
     {
         xle_log("CCSP_Message_Bus_Init failed for component %s: %d\n", component_id, ret);
-        //bus_handle = NULL;
-        //exit(1);
+        bus_handle = NULL;
+        exit(1);
     }
     int retPsmGet = PSM_Get_Record_Value2(bus_handle,g_Subsystem, "dmsb.Mesh.WAN.Interface.Name", NULL, &paramValue);
     if (retPsmGet == CCSP_SUCCESS)

--- a/source/xle_selfheal/xle_selfheal_util.c
+++ b/source/xle_selfheal/xle_selfheal_util.c
@@ -196,7 +196,7 @@ void PopulateParameters()
     if (ret != CCSP_SUCCESS)
     {
         xle_log("CCSP_Message_Bus_Init failed for component %s: %d\n", component_id, ret);
-        bus_handle = NULL;
+        //bus_handle = NULL;
         //exit(1);
     }
     int retPsmGet = PSM_Get_Record_Value2(bus_handle,g_Subsystem, "dmsb.Mesh.WAN.Interface.Name", NULL, &paramValue);

--- a/source/xle_selfheal/xle_selfheal_util.c
+++ b/source/xle_selfheal/xle_selfheal_util.c
@@ -211,13 +211,13 @@ void PopulateParameters()
 #ifdef CORE_NET_LIB
         int status;
         libnet_status result;
-        result = interface_status(current_wan_ifname, &status);
+        result = interface_status(default_wan_ifname, &status);
         if (result == CNL_STATUS_SUCCESS) {
              xle_log(" interface_status successfully retrieved\n");
         }
         if ( status == 1 )
 #else
-        sprintf(comp_status_cmd,"ifconfig %s | grep UP",current_wan_ifname);
+        sprintf(comp_status_cmd,"ifconfig %s | grep UP",default_wan_ifname);
         memset(InterfaceStatus, 0, sizeof(InterfaceStatus));
         GetInterfaceStatus( InterfaceStatus, comp_status_cmd, sizeof(comp_status_cmd) );
         if ( InterfaceStatus[0] != '\0' )

--- a/source/xle_selfheal/xle_selfheal_util.c
+++ b/source/xle_selfheal/xle_selfheal_util.c
@@ -197,7 +197,7 @@ void PopulateParameters()
     {
         xle_log("CCSP_Message_Bus_Init failed for component %s: %d\n", component_id, ret);
         bus_handle = NULL;
-        exit(1);
+        //exit(1);
     }
     int retPsmGet = PSM_Get_Record_Value2(bus_handle,g_Subsystem, "dmsb.Mesh.WAN.Interface.Name", NULL, &paramValue);
     if (retPsmGet == CCSP_SUCCESS)


### PR DESCRIPTION
Reason for change: Selfheal is checking current_wan_ifname instead of default_wan_ifname for LTE Selfheal 
Test Procedure: In case of br-home down and in extender mode, LTE selfheal should not check br-home for wwan0 connectivity. 
Risks: Medium Priority: P0 
Signed-off-by: Harnish_Patel@comcast.com