### PR TITLE
LTE-2902 : CCSP_Message_Bus_Init failed for XLE selfheal

### DIFF
--- a/source/xle_selfheal/xle_selfheal_util.c
+++ b/source/xle_selfheal/xle_selfheal_util.c
@@ -193,7 +193,7 @@ void PopulateParameters()
                                 &bus_handle,
                                 (CCSP_MESSAGE_BUS_MALLOC)Ansc_AllocateMemory_Callback,
                                 Ansc_FreeMemory_Callback);
-    if (ret != CCSP_SUCCESS)
+    if (ret != 0)
     {
         xle_log("CCSP_Message_Bus_Init failed for component %s: %d\n", component_id, ret);
         bus_handle = NULL;


### PR DESCRIPTION
Reason for change: Previous check against CCSP_SUCCESS (100) was incorrect, causing false failure logs even when initialization succeeded.
Test Procedure: Run XLE selfheal(/usr/bin/xle_selfheal 1); verify that no failure logs are printed for successful initialization. Priority: P1
Risks: None

Signed-off-by: KavyaChowdahalli_Suresh@comcast.com