### PR TITLE
RDKB-64371 : Enhance Self-Heal Script Boot-Time Log Message with Uptime Info

### DIFF
--- a/scripts/device/tccbr/self_heal_connectivity_test.sh
+++ b/scripts/device/tccbr/self_heal_connectivity_test.sh
@@ -487,7 +487,7 @@ cron_mode()
     acquire_lock "self_heal_connectivity_test" "self_heal_connectivity_test.sh"
     echo_t "RDKB_CONN_SELFHEAL : Cron job is enabled"
     if [ "$BOOTUP_TIME_SEC" -le 900 ]; then
-            echo_t "[RDKB_CONN_SELFHEAL] : Still booting, skipping"
+            echo_t "[RDKB_CONN_SELFHEAL] : Uptime is less than 15 mins, so exiting the run at $BOOTUP_TIME_SEC seconds"
             exit 0
         fi
 	if [ "$SELFHEAL_ENABLE" != "true" ]; then

--- a/scripts/resource_monitor.sh
+++ b/scripts/resource_monitor.sh
@@ -513,7 +513,7 @@ cron_mode()
 	echo_t "[RDKB_RES_SELFHEAL] : Cron job is enabled"
 	# Skip during boot (first 15 minutes)
     if [ "$BOOTUP_TIME_SEC" -le 900 ]; then
-		echo_t "[RDKB_RES_SELFHEAL] : Still booting, skipping"
+		echo_t "[RDKB_RES_SELFHEAL] : Uptime is less than 15 mins, so exiting the run at $BOOTUP_TIME_SEC seconds"
         exit 0
     fi
        

--- a/scripts/self_heal_connectivity_test.sh
+++ b/scripts/self_heal_connectivity_test.sh
@@ -689,7 +689,7 @@ cron_mode()
     echo_t "RDKB_CONN_SELFHEAL : Cron job is enabled"
 
     if [ "$BOOTUP_TIME_SEC" -le 900 ]; then
-        echo_t "[RDKB_CONN_SELFHEAL] : Still booting, skipping"
+        echo_t "[RDKB_CONN_SELFHEAL] : Uptime is less than 15 mins, so exiting the run at $BOOTUP_TIME_SEC seconds"
         exit 0
     fi
 

--- a/scripts/selfheal_aggressive.sh
+++ b/scripts/selfheal_aggressive.sh
@@ -1833,7 +1833,7 @@ cron_mode()
 	# skip during boot of first 5 minutes
 	BOOTUP_TIME_SEC=$(cut -d. -f1 /proc/uptime)
 	if [ "$BOOTUP_TIME_SEC" -le 300 ]; then
-            echo_t "[RDKB_AGG_SELFHEAL] : Still booting, skipping"
+            echo_t "[RDKB_AGG_SELFHEAL] : Uptime is less than 5 mins, so exiting the run at $BOOTUP_TIME_SEC seconds"
             exit 0
     fi
 


### PR DESCRIPTION
Reason for change: Enhance Self-Heal Script Boot-Time Log Message with Uptime Info
Test Procedure: Verify logs show uptime when skipped under 15 minutes.
Priority: P1
Risks: None

Signed-off-by: KavyaChowdahalli_Suresh@comcast.com