### PR TITLE
RDKB-64620: Fix resource leaks in LatencyMeasurement

### DIFF
--- a/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
+++ b/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
@@ -78,6 +78,7 @@ void* isMonitorService_thread_free(void *arg)
 	pthread_condattr_init(&SyncAttr);
 	pthread_condattr_setclock(&SyncAttr, CLOCK_MONOTONIC);
 	pthread_cond_init(&cond,&SyncAttr);
+	pthread_condattr_destroy(&SyncAttr);
 	while(1)
 	{	
 		memset(&ts,0,sizeof(ts));
@@ -733,12 +734,17 @@ void *SysEventHandlerThrd_for_Monitorservice(void *data)
 					curr_wan_mode=atoi(value);
 				}
 			}
-			else if(strcmp(name,LATENCY_MEASUREMENT_DISABLE)==0)
+				else if(strcmp(name,LATENCY_MEASUREMENT_DISABLE)==0)
 			{
 				CcspTraceInfo(("LATENCY_MEASUREMENT_DISABLE %s\n",__func__));
 				break;
 			}
 		}
+	}
+	if(sysevent_fd >= 0)
+	{
+		sysevent_close(sysevent_fd, sysevent_token);
+		sysevent_fd = -1;
 	}
 	pthread_detach(tid[SYSEVENT_PTHREAD_ID]);
 	CcspTraceInfo(("pthread_detach SYSEVENT_PTHREAD_ID %s\n",__func__));
@@ -775,6 +781,7 @@ void* LatencyMeasurement_MonitorService(void *arg)
 	pthread_condattr_init(&SyncAttr);
 	pthread_condattr_setclock(&SyncAttr, CLOCK_MONOTONIC);
 	pthread_cond_init(&Monitor_cond,&SyncAttr);
+	pthread_condattr_destroy(&SyncAttr);
 	LatencyMeasurementServiceInit();
 	sysevent_get(sysevent_fd_g, sysevent_token_g, "current_wan_ifname", current_wan_ifname, sizeof(strValue));
 	sysevent_get(sysevent_fd_g, sysevent_token_g, "current_wan_mode_update", strValue, sizeof(strValue));
@@ -823,6 +830,12 @@ void* LatencyMeasurement_MonitorService(void *arg)
 			break;
 		}
 	}
+	if(sysevent_fd_g >= 0)
+	{
+		sysevent_close(sysevent_fd_g, sysevent_token_g);
+		sysevent_fd_g = -1;
+	}
+	pthread_cond_destroy(&Monitor_cond);
 	pthread_detach(tid[MONITOR_PTHREAD_ID]);
 	CcspTraceInfo(("pthread_detach MONITOR_PTHREAD_ID %s\n",__func__));
 	return NULL;

--- a/source/LatencyMeasurement/TR-181/lowlatency_rbus_handler_apis.c
+++ b/source/LatencyMeasurement/TR-181/lowlatency_rbus_handler_apis.c
@@ -266,15 +266,17 @@ rbusError_t TestDiagnostic_LatencyMeasure_GetStringHandler(rbusHandle_t handle, 
 	}
     else {
         rc = LatencyMeasure_GetParamStringValue(NULL, param, value, NULL);
-        free(param);
         if(rc != 0)
         {
             CcspTraceError(("[%s]: LatencyMeasure_GetParamStringValue failed\n", __FUNCTION__));
+            free(param);
+            rbusValue_Release(val);
             return RBUS_ERROR_BUS_ERROR;
         }
         rbusValue_SetString(val, value);
     }
 
+    free(param);
     rbusProperty_SetValue(property, val);
     rbusValue_Release(val);
 

--- a/source/LatencyMeasurement/TR-181/lowlatency_util_apis.c
+++ b/source/LatencyMeasurement/TR-181/lowlatency_util_apis.c
@@ -200,6 +200,7 @@ LatencyMeasure_PublishToEvent
 		CcspTraceInfo(("%s : Publish to %s ret value is %d\n", __FUNCTION__,event_name,ret));
 	}
     /* release rbus value and object variable */
-    rbusValue_Release(value);    
+    rbusValue_Release(value);
+    rbusObject_Release(data);
     return ret;
 }


### PR DESCRIPTION
- Destroy pthread_condattr_t after cond init in isMonitorService_thread_free and LatencyMeasurement_MonitorService to release condattr resources
- Close sysevent_fd and sysevent_fd_g before thread exit to avoid fd leaks
- Add pthread_cond_destroy for Monitor_cond on monitor thread exit
- Fix param strdup leak in GetStringHandler TCP_Stats_Report branch; free param and release rbus value on error path
- Release rbusObject (data) after rbusValue_Release in LatencyMeasure_PublishToEvent