### PR TITLE
RDKB-64620: Fix resource leaks in LatencyMeasurement

### DIFF
--- a/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
+++ b/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
@@ -737,12 +737,17 @@ void *SysEventHandlerThrd_for_Monitorservice(void *data)
 					curr_wan_mode=atoi(value);
 				}
 			}
-			else if(strcmp(name,LATENCY_MEASUREMENT_DISABLE)==0)
-			{
-				CcspTraceInfo(("LATENCY_MEASUREMENT_DISABLE %s\n",__func__));
-				break;
-			}
+				else if(strcmp(name,LATENCY_MEASUREMENT_DISABLE)==0)
+				{
+					CcspTraceInfo(("LATENCY_MEASUREMENT_DISABLE %s\n",__func__));
+					break;
+				}
 		}
+	}
+	if(sysevent_fd >= 0)
+	{
+		sysevent_close(sysevent_fd, sysevent_token);
+		sysevent_fd = -1;
 	}
 	pthread_detach(tid[SYSEVENT_PTHREAD_ID]);
 	CcspTraceInfo(("pthread_detach SYSEVENT_PTHREAD_ID %s\n",__func__));

--- a/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
+++ b/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
@@ -79,6 +79,7 @@ void* isMonitorService_thread_free(void *arg)
     pthread_condattr_init(&SyncAttr);
     pthread_condattr_setclock(&SyncAttr, CLOCK_MONOTONIC);
     pthread_cond_init(&cond, &SyncAttr);
+    pthread_condattr_destroy(&SyncAttr);
     memset(&ts, 0, sizeof(ts));
     clock_gettime(CLOCK_MONOTONIC, &ts);
     ts.tv_nsec = 0;
@@ -603,12 +604,18 @@ void SendConditional_pthread_cond_signal()
 
 int LatencyMeasurementServiceInit()
 {
+	/* Close any previously opened fd before reopening to avoid fd leaks on re-enable cycles. */
+	if (sysevent_fd_g >= 0)
+	{
+		sysevent_close(sysevent_fd_g, sysevent_token_g);
+		sysevent_fd_g = -1;
+	}
 	if ((sysevent_fd_g = sysevent_open("127.0.0.1", SE_SERVER_WELL_KNOWN_PORT, SE_VERSION, "latency_measurement", &sysevent_token_g)) < 0)
-		{
-			CcspTraceInfo(("Failed to open sysevent.\n"));
-			return FALSE;
-		}
-	return 0; 
+	{
+		CcspTraceInfo(("Failed to open sysevent.\n"));
+		return FALSE;
+	}
+	return 0;
 }
 /*****************************************************************************
 	SysEventHandlerThrd_for_Monitorservice() is used to get the sysevents and based 
@@ -785,6 +792,7 @@ void* LatencyMeasurement_MonitorService(void *arg)
     pthread_condattr_init(&SyncAttr);
     pthread_condattr_setclock(&SyncAttr, CLOCK_MONOTONIC);
     pthread_cond_init(&Monitor_cond, &SyncAttr);
+    pthread_condattr_destroy(&SyncAttr);
     LatencyMeasurementServiceInit();
     sysevent_get(sysevent_fd_g, sysevent_token_g, "current_wan_ifname", current_wan_ifname, sizeof(strValue));
     sysevent_get(sysevent_fd_g, sysevent_token_g, "current_wan_mode_update", strValue, sizeof(strValue));

--- a/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
+++ b/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
@@ -744,11 +744,11 @@ void *SysEventHandlerThrd_for_Monitorservice(void *data)
 					curr_wan_mode=atoi(value);
 				}
 			}
-				else if(strcmp(name,LATENCY_MEASUREMENT_DISABLE)==0)
-				{
-					CcspTraceInfo(("LATENCY_MEASUREMENT_DISABLE %s\n",__func__));
-					break;
-				}
+			else if(strcmp(name,LATENCY_MEASUREMENT_DISABLE)==0)
+			{
+				CcspTraceInfo(("LATENCY_MEASUREMENT_DISABLE %s\n",__func__));
+				break;
+			}
 		}
 	}
 	if(sysevent_fd >= 0)

--- a/source/LatencyMeasurement/TR-181/lowlatency_apis.c
+++ b/source/LatencyMeasurement/TR-181/lowlatency_apis.c
@@ -222,12 +222,15 @@ int LowLatency_Set_TCP_Stats_Report(char* new_val) {
 		return 1;
 	}
 
-	//update and publish the value
-	CcspTraceInfo(("%s: request for value update\n", __FUNCTION__));
-
-	if (RBUS_ERROR_SUCCESS != LatencyMeasure_PublishToEvent(LM_TCP_Stats_Report, new_val)) {
-		CcspTraceError(("%s : publish value '%s' failed.\n", __FUNCTION__, new_val));
-		return 1;
+	//update and publish the value only when there is at least one subscriber
+	if (LatencyMeasure_GetTCPStatsSubscriberCount() > 0) {
+		CcspTraceInfo(("%s: request for value update\n", __FUNCTION__));
+		if (RBUS_ERROR_SUCCESS != LatencyMeasure_PublishToEvent(LM_TCP_Stats_Report, new_val)) {
+			CcspTraceError(("%s : publish value '%s' failed.\n", __FUNCTION__, new_val));
+			return 1;
+		}
+	} else {
+		CcspTraceInfo(("%s: no subscribers, skipping publish\n", __FUNCTION__));
 	}
 
 	if (g_pTCPStatsReport != NULL) 

--- a/source/LatencyMeasurement/TR-181/lowlatency_rbus_handler_apis.c
+++ b/source/LatencyMeasurement/TR-181/lowlatency_rbus_handler_apis.c
@@ -267,15 +267,17 @@ rbusError_t TestDiagnostic_LatencyMeasure_GetStringHandler(rbusHandle_t handle, 
 	}
     else {
         rc = LatencyMeasure_GetParamStringValue(NULL, param, value, NULL);
-        free(param);
         if(rc != 0)
         {
             CcspTraceError(("[%s]: LatencyMeasure_GetParamStringValue failed\n", __FUNCTION__));
+            free(param);
+            rbusValue_Release(val);
             return RBUS_ERROR_BUS_ERROR;
         }
         rbusValue_SetString(val, value);
     }
 
+    free(param);
     rbusProperty_SetValue(property, val);
     rbusValue_Release(val);
 

--- a/source/LatencyMeasurement/TR-181/lowlatency_rbus_handler_apis.c
+++ b/source/LatencyMeasurement/TR-181/lowlatency_rbus_handler_apis.c
@@ -263,7 +263,8 @@ rbusError_t TestDiagnostic_LatencyMeasure_GetStringHandler(rbusHandle_t handle, 
 
     if (strcmp(param, "X_RDK_LatencyMeasure_TCP_Stats_Report") == 0){
 		rbusValue_SetString(val, g_pTCPStatsReport);
-		free(param);
+		/* Copilot: do NOT free(param) here - it is freed unconditionally below.
+		 * Freeing here caused a double-free when this branch was taken. */
 	}
     else {
         rc = LatencyMeasure_GetParamStringValue(NULL, param, value, NULL);

--- a/source/LatencyMeasurement/TR-181/lowlatency_rbus_handler_apis.c
+++ b/source/LatencyMeasurement/TR-181/lowlatency_rbus_handler_apis.c
@@ -344,7 +344,14 @@ rbusError_t TestDiagnostic_LatencyMeasure_EventStringHandler(rbusHandle_t handle
 }
 
 
-/*** API for Event handling***/	
+/*** API for Event handling***/
+
+static int g_TCPStatsReport_subscriber_count = 0;
+
+int LatencyMeasure_GetTCPStatsSubscriberCount(void)
+{
+	return g_TCPStatsReport_subscriber_count;
+}
 
 BOOL
 LatencyMeasure_EventParamStringValue
@@ -357,11 +364,14 @@ LatencyMeasure_EventParamStringValue
 	if (strcmp(pParamName, "X_RDK_LatencyMeasure_TCP_Stats_Report") == 0) {
 		if (action == RBUS_EVENT_ACTION_SUBSCRIBE)
 		{
-			CcspTraceInfo(("Subscribers count increased for event [%s] \n", pParamName));
+			g_TCPStatsReport_subscriber_count++;
+			CcspTraceInfo(("Subscribers count increased for event [%s], count=%d\n", pParamName, g_TCPStatsReport_subscriber_count));
 		}
 		else if (action == RBUS_EVENT_ACTION_UNSUBSCRIBE)
 		{
-			CcspTraceInfo(("Subscribers count decreased for event [%s] \n", pParamName));
+			if (g_TCPStatsReport_subscriber_count > 0)
+				g_TCPStatsReport_subscriber_count--;
+			CcspTraceInfo(("Subscribers count decreased for event [%s], count=%d\n", pParamName, g_TCPStatsReport_subscriber_count));
 		}
 		return TRUE;
 	}

--- a/source/LatencyMeasurement/TR-181/lowlatency_rbus_handler_apis.h
+++ b/source/LatencyMeasurement/TR-181/lowlatency_rbus_handler_apis.h
@@ -42,12 +42,13 @@ rbusError_t TestDiagnostic_LatencyMeasure_GetStringHandler(rbusHandle_t handle, 
 rbusError_t TestDiagnostic_LatencyMeasure_SetStringHandler(rbusHandle_t handle, rbusProperty_t property, rbusSetHandlerOptions_t* opts);
 rbusError_t TestDiagnostic_LatencyMeasure_EventStringHandler(rbusHandle_t handle, rbusEventSubAction_t action, const char *eventName, rbusFilter_t filter, int32_t interval, bool *autoPublish);
 
-/*** APIs for subscribe event handling***/	
+/*** APIs for subscribe event handling***/
 BOOL
 LatencyMeasure_EventParamStringValue
     (
         char*                       pParamName,
         rbusEventSubAction_t 		action
     );
+int LatencyMeasure_GetTCPStatsSubscriberCount(void);
 
 #endif

--- a/source/LatencyMeasurement/TR-181/lowlatency_util_apis.c
+++ b/source/LatencyMeasurement/TR-181/lowlatency_util_apis.c
@@ -200,6 +200,7 @@ LatencyMeasure_PublishToEvent
 		CcspTraceInfo(("%s : Publish to %s ret value is %d\n", __FUNCTION__,event_name,ret));
 	}
     /* release rbus value and object variable */
-    rbusValue_Release(value);    
+    rbusValue_Release(value);
+    rbusObject_Release(data);
     return ret;
 }


### PR DESCRIPTION
- Destroy pthread_condattr_t after cond init in isMonitorService_thread_free
  and LatencyMeasurement_MonitorService to release condattr resources
- Close sysevent_fd and sysevent_fd_g before thread exit to avoid fd leaks
- Add pthread_cond_destroy for Monitor_cond on monitor thread exit
- Fix param strdup leak in GetStringHandler TCP_Stats_Report branch;
  free param and release rbus value on error path
- Release rbusObject (data) after rbusValue_Release in LatencyMeasure_PublishToEvent


- Track subscriber count for Device.QOS.X_RDK_LatencyMeasure_TCP_Stats_Report
  event via g_TCPStatsReport_subscriber_count in LatencyMeasure_EventParamStringValue
- Add LatencyMeasure_GetTCPStatsSubscriberCount() getter
- In LowLatency_Set_TCP_Stats_Report(), skip LatencyMeasure_PublishToEvent()
  when subscriber count is zero to avoid unnecessary RBUS overhead
- Buffer write (memset/strcpy) retained so GET handler is unaffected