### PR TITLE
RDKB-64620: Fix memory increase post deployment of latency rfc

### DIFF
--- a/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
+++ b/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
@@ -604,6 +604,11 @@ void SendConditional_pthread_cond_signal()
 
 int LatencyMeasurementServiceInit()
 {
+	if (sysevent_fd_g >= 0)
+	{
+		CcspTraceInfo(("sysevent_fd_g already open (%d), skipping sysevent_open.\n", sysevent_fd_g));
+		return 0;
+	}
 	if ((sysevent_fd_g = sysevent_open("127.0.0.1", SE_SERVER_WELL_KNOWN_PORT, SE_VERSION, "latency_measurement", &sysevent_token_g)) < 0)
 		{
 			CcspTraceInfo(("Failed to open sysevent.\n"));

--- a/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
+++ b/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
@@ -79,6 +79,7 @@ void* isMonitorService_thread_free(void *arg)
     pthread_condattr_init(&SyncAttr);
     pthread_condattr_setclock(&SyncAttr, CLOCK_MONOTONIC);
     pthread_cond_init(&cond, &SyncAttr);
+    pthread_condattr_destroy(&SyncAttr);
     memset(&ts, 0, sizeof(ts));
     clock_gettime(CLOCK_MONOTONIC, &ts);
     ts.tv_nsec = 0;
@@ -104,8 +105,7 @@ void* isMonitorService_thread_free(void *arg)
     UpdateLatencyMeasurement_EnableCount(gLowLatency_Enable);
     pthread_detach(tid[WAIT_FOR_MONITOR_FREE_PTHREAD_ID]);
     CcspTraceInfo(("pthread_detach WAIT_FOR_MONITOR_FREE_PTHREAD_ID %s\n", __func__));
-    return NULL;
-}
+    return NULL;}
 int UpdateLatencyMeasurement_EnableCount(bool LowLatency_Enable)
 {
 	char new_val_buf[20];
@@ -737,12 +737,17 @@ void *SysEventHandlerThrd_for_Monitorservice(void *data)
 					curr_wan_mode=atoi(value);
 				}
 			}
-			else if(strcmp(name,LATENCY_MEASUREMENT_DISABLE)==0)
+				else if(strcmp(name,LATENCY_MEASUREMENT_DISABLE)==0)
 			{
 				CcspTraceInfo(("LATENCY_MEASUREMENT_DISABLE %s\n",__func__));
 				break;
 			}
 		}
+	}
+	if(sysevent_fd >= 0)
+	{
+		sysevent_close(sysevent_fd, sysevent_token);
+		sysevent_fd = -1;
 	}
 	pthread_detach(tid[SYSEVENT_PTHREAD_ID]);
 	CcspTraceInfo(("pthread_detach SYSEVENT_PTHREAD_ID %s\n",__func__));
@@ -833,10 +838,15 @@ void* LatencyMeasurement_MonitorService(void *arg)
             break;
         }
     }
+    if(sysevent_fd_g >= 0)
+    {
+        sysevent_close(sysevent_fd_g, sysevent_token_g);
+        sysevent_fd_g = -1;
+    }
+    pthread_cond_destroy(&Monitor_cond);
     pthread_detach(tid[MONITOR_PTHREAD_ID]);
     CcspTraceInfo(("pthread_detach MONITOR_PTHREAD_ID %s\n", __func__));
-    return NULL;
-}
+    return NULL;}
 /*****************************************************************************
 	LatencyMeasurement_Config_Init() is used for Xnet services configuration initialization
 ******************************************************************************/

--- a/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
+++ b/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
@@ -845,11 +845,6 @@ void* LatencyMeasurement_MonitorService(void *arg)
             break;
         }
     }
-    if(sysevent_fd_g >= 0)
-    {
-        sysevent_close(sysevent_fd_g, sysevent_token_g);
-        sysevent_fd_g = -1;
-    }
     pthread_cond_destroy(&Monitor_cond);
     pthread_detach(tid[MONITOR_PTHREAD_ID]);
     CcspTraceInfo(("pthread_detach MONITOR_PTHREAD_ID %s\n", __func__));

--- a/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
+++ b/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
@@ -786,6 +786,7 @@ void* LatencyMeasurement_MonitorService(void *arg)
     pthread_condattr_init(&SyncAttr);
     pthread_condattr_setclock(&SyncAttr, CLOCK_MONOTONIC);
     pthread_cond_init(&Monitor_cond, &SyncAttr);
+    pthread_condattr_destroy(&SyncAttr);
     LatencyMeasurementServiceInit();
     sysevent_get(sysevent_fd_g, sysevent_token_g, "current_wan_ifname", current_wan_ifname, sizeof(strValue));
     sysevent_get(sysevent_fd_g, sysevent_token_g, "current_wan_mode_update", strValue, sizeof(strValue));

--- a/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
+++ b/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
@@ -105,7 +105,8 @@ void* isMonitorService_thread_free(void *arg)
     UpdateLatencyMeasurement_EnableCount(gLowLatency_Enable);
     pthread_detach(tid[WAIT_FOR_MONITOR_FREE_PTHREAD_ID]);
     CcspTraceInfo(("pthread_detach WAIT_FOR_MONITOR_FREE_PTHREAD_ID %s\n", __func__));
-    return NULL;}
+    return NULL;
+}
 int UpdateLatencyMeasurement_EnableCount(bool LowLatency_Enable)
 {
 	char new_val_buf[20];
@@ -737,7 +738,7 @@ void *SysEventHandlerThrd_for_Monitorservice(void *data)
 					curr_wan_mode=atoi(value);
 				}
 			}
-				else if(strcmp(name,LATENCY_MEASUREMENT_DISABLE)==0)
+			else if(strcmp(name,LATENCY_MEASUREMENT_DISABLE)==0)
 			{
 				CcspTraceInfo(("LATENCY_MEASUREMENT_DISABLE %s\n",__func__));
 				break;
@@ -846,7 +847,8 @@ void* LatencyMeasurement_MonitorService(void *arg)
     pthread_cond_destroy(&Monitor_cond);
     pthread_detach(tid[MONITOR_PTHREAD_ID]);
     CcspTraceInfo(("pthread_detach MONITOR_PTHREAD_ID %s\n", __func__));
-    return NULL;}
+    return NULL;
+}
 /*****************************************************************************
 	LatencyMeasurement_Config_Init() is used for Xnet services configuration initialization
 ******************************************************************************/

--- a/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
+++ b/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
@@ -845,7 +845,11 @@ void* LatencyMeasurement_MonitorService(void *arg)
             break;
         }
     }
-    pthread_cond_destroy(&Monitor_cond);
+    /* Monitor_cond is shared with other threads (including detached/background
+     * signalers). Do not destroy it here unless all users have been stopped
+     * and joined; keep it for process lifetime to avoid racing with
+     * pthread_cond_signal()/pthread_cond_timedwait() on other threads.
+     */
     pthread_detach(tid[MONITOR_PTHREAD_ID]);
     CcspTraceInfo(("pthread_detach MONITOR_PTHREAD_ID %s\n", __func__));
     return NULL;

--- a/source/LatencyMeasurement/TR-181/lowlatency_rbus_handler_apis.c
+++ b/source/LatencyMeasurement/TR-181/lowlatency_rbus_handler_apis.c
@@ -267,15 +267,17 @@ rbusError_t TestDiagnostic_LatencyMeasure_GetStringHandler(rbusHandle_t handle, 
 	}
     else {
         rc = LatencyMeasure_GetParamStringValue(NULL, param, value, NULL);
-        free(param);
         if(rc != 0)
         {
             CcspTraceError(("[%s]: LatencyMeasure_GetParamStringValue failed\n", __FUNCTION__));
+            free(param);
+            rbusValue_Release(val);
             return RBUS_ERROR_BUS_ERROR;
         }
         rbusValue_SetString(val, value);
     }
 
+    free(param);
     rbusProperty_SetValue(property, val);
     rbusValue_Release(val);
 

--- a/source/LatencyMeasurement/TR-181/lowlatency_rbus_handler_apis.c
+++ b/source/LatencyMeasurement/TR-181/lowlatency_rbus_handler_apis.c
@@ -263,7 +263,6 @@ rbusError_t TestDiagnostic_LatencyMeasure_GetStringHandler(rbusHandle_t handle, 
 
     if (strcmp(param, "X_RDK_LatencyMeasure_TCP_Stats_Report") == 0){
 		rbusValue_SetString(val, g_pTCPStatsReport);
-		free(param);
 	}
     else {
         rc = LatencyMeasure_GetParamStringValue(NULL, param, value, NULL);

--- a/source/LatencyMeasurement/TR-181/lowlatency_util_apis.c
+++ b/source/LatencyMeasurement/TR-181/lowlatency_util_apis.c
@@ -200,7 +200,7 @@ LatencyMeasure_PublishToEvent
 		CcspTraceInfo(("%s : Publish to %s ret value is %d\n", __FUNCTION__,event_name,ret));
 	}
     /* release rbus value and object variable */
-    rbusValue_Release(value);
+    rbusValue_Release(value);    
     rbusObject_Release(data);
     return ret;
 }

--- a/source/LatencyMeasurement/TR-181/lowlatency_util_apis.c
+++ b/source/LatencyMeasurement/TR-181/lowlatency_util_apis.c
@@ -200,6 +200,7 @@ LatencyMeasure_PublishToEvent
 		CcspTraceInfo(("%s : Publish to %s ret value is %d\n", __FUNCTION__,event_name,ret));
 	}
     /* release rbus value and object variable */
-    rbusValue_Release(value);    
+    rbusValue_Release(value);
+    rbusObject_Release(data);
     return ret;
 }


### PR DESCRIPTION
Reason for change: memleak when enable latency rfc
Test Procedure:
Risks: Low
Signed-off-by:[Veeraputhiran_Thangavel@comcast.com](mailto:Veeraputhiran_Thangavel@comcast.com)