### PR TITLE
RDKB-64620: Fix memory increase post deployment of latency rfc

### DIFF
--- a/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
+++ b/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
@@ -745,6 +745,11 @@ void *SysEventHandlerThrd_for_Monitorservice(void *data)
 			}
 		}
 	}
+	if(sysevent_fd >= 0)
+	{
+		sysevent_close(sysevent_fd, sysevent_token);
+		sysevent_fd = -1;
+	}
 	pthread_detach(tid[SYSEVENT_PTHREAD_ID]);
 	CcspTraceInfo(("pthread_detach SYSEVENT_PTHREAD_ID %s\n",__func__));
 	return NULL;

--- a/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
+++ b/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
@@ -604,6 +604,11 @@ void SendConditional_pthread_cond_signal()
 
 int LatencyMeasurementServiceInit()
 {
+	if (sysevent_fd_g >= 0)
+	{
+		CcspTraceInfo(("sysevent_fd_g already open (%d), skipping sysevent_open.\n", sysevent_fd_g));
+		return 0;
+	}
 	if ((sysevent_fd_g = sysevent_open("127.0.0.1", SE_SERVER_WELL_KNOWN_PORT, SE_VERSION, "latency_measurement", &sysevent_token_g)) < 0)
 		{
 			CcspTraceInfo(("Failed to open sysevent.\n"));

--- a/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
+++ b/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
@@ -781,6 +781,7 @@ void* LatencyMeasurement_MonitorService(void *arg)
     pthread_condattr_init(&SyncAttr);
     pthread_condattr_setclock(&SyncAttr, CLOCK_MONOTONIC);
     pthread_cond_init(&Monitor_cond, &SyncAttr);
+    pthread_condattr_destroy(&SyncAttr);
     LatencyMeasurementServiceInit();
     sysevent_get(sysevent_fd_g, sysevent_token_g, "current_wan_ifname", current_wan_ifname, sizeof(strValue));
     sysevent_get(sysevent_fd_g, sysevent_token_g, "current_wan_mode_update", strValue, sizeof(strValue));

--- a/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
+++ b/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
@@ -845,7 +845,6 @@ void* LatencyMeasurement_MonitorService(void *arg)
             break;
         }
     }
-    pthread_cond_destroy(&Monitor_cond);
     pthread_detach(tid[MONITOR_PTHREAD_ID]);
     CcspTraceInfo(("pthread_detach MONITOR_PTHREAD_ID %s\n", __func__));
     return NULL;

--- a/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
+++ b/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
@@ -79,6 +79,7 @@ void* isMonitorService_thread_free(void *arg)
     pthread_condattr_init(&SyncAttr);
     pthread_condattr_setclock(&SyncAttr, CLOCK_MONOTONIC);
     pthread_cond_init(&cond, &SyncAttr);
+    pthread_condattr_destroy(&SyncAttr);
     memset(&ts, 0, sizeof(ts));
     clock_gettime(CLOCK_MONOTONIC, &ts);
     ts.tv_nsec = 0;

--- a/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
+++ b/source/LatencyMeasurement/ServiceMonitor/ServiceMonitor.c
@@ -835,6 +835,7 @@ void* LatencyMeasurement_MonitorService(void *arg)
             break;
         }
     }
+    pthread_cond_destroy(&Monitor_cond);
     pthread_detach(tid[MONITOR_PTHREAD_ID]);
     CcspTraceInfo(("pthread_detach MONITOR_PTHREAD_ID %s\n", __func__));
     return NULL;

--- a/source/LatencyMeasurement/TR-181/lowlatency_rbus_handler_apis.c
+++ b/source/LatencyMeasurement/TR-181/lowlatency_rbus_handler_apis.c
@@ -263,19 +263,20 @@ rbusError_t TestDiagnostic_LatencyMeasure_GetStringHandler(rbusHandle_t handle, 
 
     if (strcmp(param, "X_RDK_LatencyMeasure_TCP_Stats_Report") == 0){
 		rbusValue_SetString(val, g_pTCPStatsReport);
-		free(param);
 	}
     else {
         rc = LatencyMeasure_GetParamStringValue(NULL, param, value, NULL);
-        free(param);
         if(rc != 0)
         {
             CcspTraceError(("[%s]: LatencyMeasure_GetParamStringValue failed\n", __FUNCTION__));
+            free(param);
+            rbusValue_Release(val);
             return RBUS_ERROR_BUS_ERROR;
         }
         rbusValue_SetString(val, value);
     }
 
+    free(param);
     rbusProperty_SetValue(property, val);
     rbusValue_Release(val);
 

--- a/source/LatencyMeasurement/TR-181/lowlatency_util_apis.c
+++ b/source/LatencyMeasurement/TR-181/lowlatency_util_apis.c
@@ -201,5 +201,6 @@ LatencyMeasure_PublishToEvent
 	}
     /* release rbus value and object variable */
     rbusValue_Release(value);    
+    rbusObject_Release(data);
     return ret;
 }


### PR DESCRIPTION
Reason for change: memleak when enable latency rfc
Test Procedure:
Risks: Low
Signed-off-by:Veeraputhiran_Thangavel@comcast.com