### PR TITLE
RDKB-65075: Fix native build failure

### DIFF
--- a/cov_docker_script/configure_options.conf
+++ b/cov_docker_script/configure_options.conf
@@ -9,6 +9,9 @@
 # Autotools configuration
 -DHAVE_CONFIG_H
 
+# Safec dummy API
+-DSAFEC_DUMMY_API
+
 # Include paths
 -I$HOME/usr/include/rdkb/
 -I$HOME/usr/include/rdkb/rbus/

--- a/source/dmltad/cosa_wanconnectivity_rbus_apis.c
+++ b/source/dmltad/cosa_wanconnectivity_rbus_apis.c
@@ -435,7 +435,7 @@ ANSC_STATUS CosaWanCnctvtyChk_Intf_Commit (PCOSA_DML_WANCNCTVTY_CHK_INTF_INFO  p
 **********************************************************************/
 ANSC_STATUS CosaWanCnctvtyChk_URL_delDBEntry (unsigned int InstanceNumber)
 {
-    char paramName[BUFLEN_128];
+    char paramName[BUFLEN_128] = {0};
     int url_max_inst = 0;
     errno_t rc = -1;
     PSINGLE_LINK_ENTRY              pSListEntry       = NULL;


### PR DESCRIPTION
Reason for change: Native build for Coverity scan
Test Procedure: Native build should be success
Priority: P1
Risks: None
Signed-off-by: Netaji Panigrahi [Netaji_Panigrahi@comcast.com](mailto:Netaji_Panigrahi@comcast.com)