### PR TITLE
RDKB-64184, RDKB-64546 : SelfHeal for Network Intelligence process

### DIFF
--- a/scripts/corrective_action.sh
+++ b/scripts/corrective_action.sh
@@ -916,6 +916,11 @@ resetNeeded()
                     advsec_restart_agent
                 fi
 
+            elif [ "$SELFHEAL_TYPE" = "BASE" ] && [ "$ProcessName" = "cujo-qosd" ]; then
+                echo_t "RDKB_SELFHEAL : Resetting process $ProcessName"
+                systemctl start cujo-ni
+                t2CountNotify "SYS_SH_CUJO_NI_restart"
+
             elif [ "$ProcessName" = "PING" ]; then
                 REBOOTINTERVAL=$(syscfg get router_reboot_Interval)
                 LAST_REBOOT=$(syscfg get last_router_reboot_time)

--- a/scripts/corrective_action.sh
+++ b/scripts/corrective_action.sh
@@ -916,7 +916,7 @@ resetNeeded()
                     advsec_restart_agent
                 fi
 
-            elif [ "$SELFHEAL_TYPE" = "BASE" ] && [ "$ProcessName" = "cujo-qosd" ]; then
+            elif [ "$ProcessName" = "cujo-qosd" ]; then
                 echo_t "RDKB_SELFHEAL : Resetting process $ProcessName"
                 systemctl start cujo-ni
                 t2CountNotify "SYS_SH_CUJO_NI_restart"

--- a/scripts/task_health_monitor.sh
+++ b/scripts/task_health_monitor.sh
@@ -1505,6 +1505,15 @@ else
                             resetNeeded advsec CcspAdvSecuritySsp
                             isADVPID=1
                         fi
+                        # cujo-qosd
+                        NI_ENABLED=$(dmcli eRT retv Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.NetworkIntelligence.Enable)
+                        if [ "$NI_ENABLED" = "true" ]; then
+                            NI_PID=$(pidof cujo-qosd)
+                            if [ "$NI_PID" = "" ] ; then
+                                echo_t "RDKB_PROCESS_CRASHED : cujo-qosd process is not running, need restart"
+                                resetNeeded "" cujo-qosd
+                            fi
+                        fi
                     ;;
                     "TCCBR")
                     ;;

--- a/scripts/task_health_monitor.sh
+++ b/scripts/task_health_monitor.sh
@@ -1505,15 +1505,6 @@ else
                             resetNeeded advsec CcspAdvSecuritySsp
                             isADVPID=1
                         fi
-                        # cujo-qosd
-                        NI_ENABLED=$(dmcli eRT retv Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.NetworkIntelligence.Enable)
-                        if [ "$NI_ENABLED" = "true" ]; then
-                            NI_PID=$(pidof cujo-qosd)
-                            if [ "$NI_PID" = "" ] ; then
-                                echo_t "RDKB_PROCESS_CRASHED : cujo-qosd process is not running, need restart"
-                                resetNeeded "" cujo-qosd
-                            fi
-                        fi
                     ;;
                     "TCCBR")
                     ;;
@@ -1550,6 +1541,15 @@ else
                             ;;
                         esac
                     fi  # [ -f $ADVSEC_PATH ]
+                    # cujo-qosd
+                    NI_ENABLED=$(dmcli eRT retv Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.NetworkIntelligence.Enable)
+                    if [ "$NI_ENABLED" = "true" ]; then
+                        NI_PID=$(pidof cujo-qosd)
+                        if [ "$NI_PID" = "" ] ; then
+                            echo_t "RDKB_PROCESS_CRASHED : cujo-qosd process is not running, need restart"
+                            resetNeeded "" cujo-qosd
+                        fi
+                    fi
                 fi  # [ "$advsec_bridge_mode" != "2" ]
 fi #BWG
 case $SELFHEAL_TYPE in


### PR DESCRIPTION
Reason for change: If NI RFC is enabled and cujo-qosd process is not running, then restart cujo-ni service for recovery
Test Procedure:
1) If NI RFC is enabled and cujo-ni service is not active, then it should be recovered by selfheal script

Risks: Low
Priority: P1

Signed-off-by: Santhosh_GujulvaJagadeesh@comcast.com