### PR TITLE
CBR2-2255: Observing multiple "RDKB_PROCESS_CRASHED : rsync_dropbear_…

### DIFF
--- a/scripts/selfheal_aggressive.sh
+++ b/scripts/selfheal_aggressive.sh
@@ -1380,17 +1380,6 @@ self_heal_dropbear()
          "BASE")
              # TODO: move DROPBEAR BASE code with TCCBR,SYSTEMD code!
          ;;
-         "TCCBR")
-             #Check dropbear is alive to do rsync/scp to/fro ATOM
-             if [ "$ARM_INTERFACE_IP" != "" ] && [ ! -f "/nvram/ETHWAN_ENABLE" ]; then
-                 DROPBEAR_ENABLE=$(ps -ww | grep "dropbear" | grep "$ARM_INTERFACE_IP")
-                 if [ "$DROPBEAR_ENABLE" = "" ]; then
-                     echo_t "RDKB_PROCESS_CRASHED : rsync_dropbear_process is not running, need restart"
-                     t2CountNotify "SYS_SH_Dropbear_restart"
-                     dropbear -E -s -p $ARM_INTERFACE_IP:22 > /dev/null 2>&1
-                 fi
-             fi
-         ;;
          "SYSTEMD")
              if [ "$BOX_TYPE" != "HUB4" ] && [ "$BOX_TYPE" != "SR300" ] && [ "$BOX_TYPE" != "SE501" ] && [ "$BOX_TYPE" != "SR213" ] && [ "$BOX_TYPE" != "WNXL11BWL" ] && [ "$BOX_TYPE" != "SCER11BEL" ] &&  [ "$BOX_TYPE" != "SCXF11BFL" ]; then
                  #Checking dropbear PID


### PR DESCRIPTION
…process" logs

Reason for change:  ARM_INTERFACE_IP check is removed as dropbear only on IPV6 Test Procedure:
  - Crash log should not be seen in CBR2 during bootup Priority: P1

- [] Is this a User Story (US)? This is a bug ticket

- [x] Have all dependent PRs from other components been listed ?

- [x] Does the commit message include both the User Story ticket and the Subtask ticket?

- [x] Will be all changes related to the User Story squashed and merged in a single commit?

- [x]  Has the PR been raised only after completing all changes for the User Story (no partial changes)?

- [x] Has code development for the User Story been completed?

- [x] If yes, has the Gerrit topic or list of all dependent PRs across components (including meta-layer changes) been shared? https://gerrit.teamccp.com/#/c/953000/

- [x] Is there a validation log available in the Jira ticket for verifying builds with the updated generic-srcrev.inc across all platforms?