### PR TITLE
XER2-RDKB-65709: Enable test-and-diagnostic support for the XER2 plat…

### DIFF
--- a/source/util/rxtx_100.c
+++ b/source/util/rxtx_100.c
@@ -940,7 +940,7 @@ static int fetch_port_stats(char *ifname,uint64_t *rx_bytes,uint64_t *tx_bytes)
 {
 int ret = SUCCESS;
 #if (((!defined(_SR213_PRODUCT_REQ_) && ( defined(_HUB4_PRODUCT_REQ_)  || defined(_SR300_PRODUCT_REQ_))) \
-|| defined (_SE501_PRODUCT_REQ_) || defined(_WNXL11BWL_PRODUCT_REQ_) || defined(_XER5_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_) || defined(_SCXF11BFL_PRODUCT_REQ_)) && !defined(_COSA_QCA_ARM_))
+|| defined (_SE501_PRODUCT_REQ_) || defined(_WNXL11BWL_PRODUCT_REQ_) || defined(_XER5_PRODUCT_REQ_) || defined(_SCER11BEL_PRODUCT_REQ_) || defined(_SCXF11BFL_PRODUCT_REQ_) || defined(_XER2_PRODUCT_REQ_)) && !defined(_COSA_QCA_ARM_))
     if (ret == SUCCESS)
     {
         *rx_bytes = NEGATIVE_VALUE;


### PR DESCRIPTION
…form

Reason for change: test-and-diagnostic support for XER2

Test Procedure: Build should work
Priority:P1
Risks:Low