### PR TITLE
RDK-60738: Remove Sensitive StringFrom Open Source

### DIFF
--- a/scripts/task_health_monitor.sh
+++ b/scripts/task_health_monitor.sh
@@ -634,7 +634,7 @@ case $SELFHEAL_TYPE in
                 WIFI_QUERY_ERROR=1
             fi
 
-            SSH_ATOM_TEST=$(GetConfigFile /tmp/elxrretyt.swr stdout | ssh -I $IDLE_TIMEOUT -i /dev/stdin root@$ATOM_IP exit 2>&1)
+            SSH_ATOM_TEST=$(GetConfigFile /tmp/interchip stdout | ssh -I $IDLE_TIMEOUT -i /dev/stdin root@$ATOM_IP exit 2>&1)
             echo_t "SSH_ATOM_TEST : $SSH_ATOM_TEST"
             SSH_ERROR=`echo $SSH_ATOM_TEST | grep "Remote closed the connection"`
             SSH_TIMEOUT=`echo $SSH_ATOM_TEST | grep "Idle timeout"`


### PR DESCRIPTION
Reason for change: Remove Sensitive String (Pattern055) From Open Source
Test Procedure: Tested the tasks locally
Risks: Low
Signed-off-by: Aruna_Appikatla@comcast.com