### PR TITLE
RDKB-66118 : Update dbus dependency repository and branch for native build

### DIFF
--- a/cov_docker_script/component_config.json
+++ b/cov_docker_script/component_config.json
@@ -202,7 +202,7 @@
       {
         "name": "dbus",
         "repo": "https://gitlab.freedesktop.org/dbus/dbus.git",
-        "branch" : "dbus-1.14",
+        "branch": "dbus-1.14",
         "build": {
           "type": "cmake",
           "build_dir": "build",

--- a/cov_docker_script/component_config.json
+++ b/cov_docker_script/component_config.json
@@ -201,8 +201,8 @@
       },
       {
         "name": "dbus",
-        "repo": "https://github.com/deepin-community/dbus.git",
-        "branch" : "master",
+        "repo": "https://gitlab.freedesktop.org/dbus/dbus.git",
+        "branch" : "dbus-1.14",
         "build": {
           "type": "cmake",
           "build_dir": "build",


### PR DESCRIPTION
Reason for change: Address PR native build failure

Test Procedure: PR native builds should pass
Risks: Low

Priority: P1