### PR TITLE
TCXB7-7222: Fix false-positive connectivity check in check_gw_health.sh

### DIFF
--- a/scripts/check_gw_health.sh
+++ b/scripts/check_gw_health.sh
@@ -290,9 +290,12 @@ CheckandSetConnectivityStatus() {
         else
             #check if dig is available
             if which dig > /dev/null; then
-                output=$(dig @$3 $2)
+                # any DNS response (incl. NXDOMAIN) = reachable; only a
+                # timeout / no reply from the server is a failure
+                output=$(dig @$3 $2 2>&1)
+                result=$?
                 echo_t "$output"
-                if [ -z "$output" ]; then
+                if [ $result -ne 0 ] || echo "$output" | grep -qiE "connection timed out|no servers could be reached"; then
                     result=1
                 else
                     result=0


### PR DESCRIPTION
Reason for change: check_dns() treated any non-empty dig output as success, but dig always prints its header/comment block even when the query fails (e.g. "connection timed out; no servers could be reached"). This caused failed IPv6 DNS lookups to be counted as successes, so ConnectivityStatus was wrongly marked healthy and the self-heal reboot was skipped.

Test Procedure:
Forced an unreachable DNS (sysevent set ipv6_dns_0 2001:db8::1) → connectivity check correctly reports failure → wan_link_heal reboot triggered.
Restored real DNS → all lookups resolve → connectivity passes → no reboot.
Verified dig returns exit 0 for a reachable NXDOMAIN vs exit 9 on timeout on target hardware.

Risks: Medium
Priority: P0
Signed-off-by: balajichowdary_unnam@comcast.com